### PR TITLE
Added code for removing white spaces

### DIFF
--- a/src/calc.py
+++ b/src/calc.py
@@ -23,6 +23,7 @@ class Calc:
 		exp1 = self.__parse_Primary__(expr)
 
 		try:
+			
 			while (expr[0] == "+"):
 				del[expr[0]]
 				exp2 = self.__parse_Primary__(expr)
@@ -84,16 +85,24 @@ class Calc:
 			return exp
 
 		elif (expr[0] == "\n"):	
-				print "new line"	
+				print ("new line")
+
+  		
+			
 
 	def parse_Num(self, expr):
 
+
 		num = 0
 		numLen = len(expr)
+		for i in expr:
+			if(i == " "):
+				expr.remove(i)
 		toknum = ""
 		i = 0
 		
 		while i < numLen:
+
 
 			if (expr[0].isdigit() == False):
 				return num	


### PR DESCRIPTION
Added code for removing white spaces in the expression.
I tested it on PRINT 23 * 10 + 30  and PRINT 23- 698 * ( 4*(63-25*69)-56). However, it is working only if there is just one expression in source.bas  file. It is not working if there are multiple expressions in source.bas
For e.g -
PRINT 23-698*(4*(63-25*69)-56)
PRINT 2 * 3
PRINT 3 * 9 * 7
Here only one expression is getting evaluated.
